### PR TITLE
Gera/spark 41 shim

### DIFF
--- a/build/buildall
+++ b/build/buildall
@@ -174,8 +174,9 @@ if [[ "$DIST_PROFILE" == *Scala213 ]]; then
   SCALA213=1
 fi
 
+MVN=${MVN:-"mvn"}
 # include options to mvn command
-export MVN="mvn -Dmaven.wagon.http.retryHandler.count=3 ${MVN_OPT}"
+export MVN="$MVN -Dmaven.wagon.http.retryHandler.count=3 ${MVN_OPT}"
 
 if [[ "$SCALA213" == "1" ]]; then
   POM_FILE="scala2.13/pom.xml"

--- a/build/buildall
+++ b/build/buildall
@@ -38,7 +38,7 @@ function print_usage() {
   echo "   -gb, --generate-bloop"
   echo "        generate projects for Bloop clients: IDE (Scala Metals, IntelliJ) or Bloop CLI"
   echo "   -p=DIST_PROFILE, --profile=DIST_PROFILE"
-  echo "        use this profile for the dist module, default: noSnapshots, also supported: snapshots, minimumFeatureVersionMix,"
+  echo "        use this profile for the dist module, default: noSnapshots, also supported: snapshots,"
   echo "        snapshotsWithDatabricks, noSnapshotsWithDatabricks"
   echo "        NOTE: the Databricks-related spark3XYdb shims are not built locally, the jars are fetched prebuilt from a"
   echo " .      remote Maven repo. You can also supply a comma-separated list of build versions. E.g., --profile=330,331 will"
@@ -154,7 +154,7 @@ case "$1" in
   ;;
 
 -o=*|--option=*)
-  MVN_OPT="${1#*=}"
+  export MVN_OPT="${1#*=}"
   ;;
 
 *)
@@ -180,11 +180,12 @@ export MVN="$MVN -Dmaven.wagon.http.retryHandler.count=3 ${MVN_OPT}"
 
 if [[ "$SCALA213" == "1" ]]; then
   POM_FILE="scala2.13/pom.xml"
-  MVN="$MVN -f scala2.13/"
+  export MVN="$MVN -f scala2.13/"
   $(dirname $0)/make-scala-version-build-files.sh 2.13
 else 
   POM_FILE="pom.xml"
 fi
+
 DIST_PROFILE=${DIST_PROFILE:-"noSnapshots"}
 
 
@@ -201,9 +202,7 @@ case $DIST_PROFILE in
     SPARK_SHIM_VERSIONS=($(versionsFromReleaseProfiles "no_snapshots" $POM_FILE))
     ;;
 
-  minimumFeatureVersionMix)
-    SPARK_SHIM_VERSIONS=($(versionsFromDistProfile "minimumFeatureVersionMix"))
-    ;;
+
 
   [34]*)
     <<< $DIST_PROFILE IFS="," read -ra SPARK_SHIM_VERSIONS

--- a/dist/unshimmed-common-from-single-shim.txt
+++ b/dist/unshimmed-common-from-single-shim.txt
@@ -1,8 +1,6 @@
 META-INF/DEPENDENCIES
 META-INF/LICENSE
 META-INF/NOTICE
-com/nvidia/spark/GpuCachedBatchSerializer*
-com/nvidia/spark/ParquetCachedBatchSerializer*
 com/nvidia/spark/rapids/ExplainPlan.class
 com/nvidia/spark/rapids/ExplainPlan$.class
 com/nvidia/spark/rapids/ExplainPlanBase.class

--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -17,6 +17,7 @@ pandas
 pyarrow == 17.0.0 ; python_version == '3.8'
 pyarrow == 19.0.1 ; python_version >= '3.9'
 pytest-xdist >= 2.0.0
+pytz
 findspark
 fsspec == 2025.3.0
 fastparquet == 2024.5.0 ; python_version >= '3.9'

--- a/integration_tests/run_pyspark_from_build.sh
+++ b/integration_tests/run_pyspark_from_build.sh
@@ -79,7 +79,7 @@ else
     # PySpark uses ".dev0" for "-SNAPSHOT" and either ".dev" for "preview" or ".devN" for "previewN"
     # https://github.com/apache/spark/blob/66f25e314032d562567620806057fcecc8b71f08/dev/create-release/release-build.sh#L267
     VERSION_STRING=$(PYTHONPATH=${SPARK_HOME}/python:${PY4J_FILE} python -c \
-        "import pyspark, re; print(re.sub('\.dev[012]?$', '', pyspark.__version__))"
+        "import pyspark, re; print(re.sub(r'\.dev[012]?$', '', pyspark.__version__))"
     )
     SCALA_VERSION=`$SPARK_HOME/bin/pyspark --version 2>&1| grep Scala | awk '{split($4,v,"."); printf "%s.%s", v[1], v[2]}'`
 

--- a/pom.xml
+++ b/pom.xml
@@ -784,8 +784,6 @@
                 <parquet.hadoop.version>1.13.1</parquet.hadoop.version>
                 <rapids.delta.artifactId1>rapids-4-spark-delta-stub</rapids.delta.artifactId1>
                 <slf4j.version>2.0.7</slf4j.version>
-                <enforcer.java.versionSpec>[17,)</enforcer.java.versionSpec>
-                <enforcer.java.message>Support for Spark ${spark.version} is only available with Java 17+</enforcer.java.message>
             </properties>
             <modules>
                 <module>delta-lake/delta-stub</module>
@@ -991,7 +989,7 @@
         <spark411.version>4.1.1</spark411.version>
         <mockito.version>3.12.4</mockito.version>
         <!-- same as Apache Spark 4.0.0 for Scala 2.13 except for cloudera shims -->
-        <scala.plugin.version>4.9.8</scala.plugin.version>
+        <scala.plugin.version>4.9.2</scala.plugin.version>
         <maven.install.plugin.version>3.1.1</maven.install.plugin.version>
         <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
         <scalatest-maven-plugin.version>2.0.2</scalatest-maven-plugin.version>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -784,8 +784,6 @@
                 <parquet.hadoop.version>1.13.1</parquet.hadoop.version>
                 <rapids.delta.artifactId1>rapids-4-spark-delta-stub</rapids.delta.artifactId1>
                 <slf4j.version>2.0.7</slf4j.version>
-                <enforcer.java.versionSpec>[17,)</enforcer.java.versionSpec>
-                <enforcer.java.message>Support for Spark ${spark.version} is only available with Java 17+</enforcer.java.message>
             </properties>
             <modules>
                 <module>delta-lake/delta-stub</module>

--- a/scala2.13/pom.xml
+++ b/scala2.13/pom.xml
@@ -991,7 +991,7 @@
         <spark411.version>4.1.1</spark411.version>
         <mockito.version>3.12.4</mockito.version>
         <!-- same as Apache Spark 4.0.0 for Scala 2.13 except for cloudera shims -->
-        <scala.plugin.version>4.9.8</scala.plugin.version>
+        <scala.plugin.version>4.9.2</scala.plugin.version>
         <maven.install.plugin.version>3.1.1</maven.install.plugin.version>
         <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
         <scalatest-maven-plugin.version>2.0.2</scalatest-maven-plugin.version>

--- a/sql-plugin-api/src/main/scala/com/nvidia/spark/ParquetCachedBatchSerializer.scala
+++ b/sql-plugin-api/src/main/scala/com/nvidia/spark/ParquetCachedBatchSerializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin-api/src/main/scala/com/nvidia/spark/ParquetCachedBatchSerializer.scala
+++ b/sql-plugin-api/src/main/scala/com/nvidia/spark/ParquetCachedBatchSerializer.scala
@@ -16,7 +16,7 @@
 
 package com.nvidia.spark
 
-import com.nvidia.spark.rapids.ShimLoaderTemp
+import com.nvidia.spark.rapids.ShimLoader
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -41,7 +41,7 @@ trait GpuCachedBatchSerializer extends CachedBatchSerializer {
  */
 class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer {
 
-  private lazy val realImpl = ShimLoaderTemp.newParquetCachedBatchSerializer()
+  private lazy val realImpl = ShimLoader.newParquetCachedBatchSerializer()
 
   /**
    * Can `convertColumnarBatchToCachedBatch()` be called instead of

--- a/sql-plugin-api/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
+++ b/sql-plugin-api/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
@@ -21,6 +21,7 @@ import java.net.URL
 import scala.collection.JavaConverters.enumerationAsScalaIteratorConverter
 import scala.util.Try
 
+import com.nvidia.spark.GpuCachedBatchSerializer
 import org.apache.commons.lang3.reflect.MethodUtils
 
 import org.apache.spark.{SPARK_BRANCH, SPARK_BUILD_DATE, SPARK_BUILD_USER, SPARK_REPO_URL, SPARK_REVISION, SPARK_VERSION, SparkConf, SparkEnv}
@@ -382,4 +383,10 @@ object ShimLoader {
   def loadGpuColumnVector(): Class[_] = {
     ShimReflectionUtils.loadClass("com.nvidia.spark.rapids.GpuColumnVector")
   }
+
+  def newParquetCachedBatchSerializer(): GpuCachedBatchSerializer = {
+    ShimReflectionUtils.newInstanceOf(
+      "com.nvidia.spark.rapids.parquet.ParquetCachedBatchSerializer")
+  }
+
 }

--- a/sql-plugin-api/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
+++ b/sql-plugin-api/src/main/scala/com/nvidia/spark/rapids/ShimLoader.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoaderTemp.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoaderTemp.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoaderTemp.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/ShimLoaderTemp.scala
@@ -16,7 +16,6 @@
 
 package com.nvidia.spark.rapids
 
-import com.nvidia.spark.GpuCachedBatchSerializer
 import com.nvidia.spark.rapids.delta.DeltaProbe
 import com.nvidia.spark.rapids.iceberg.IcebergProvider
 
@@ -30,11 +29,6 @@ object ShimLoaderTemp {
 
   def newOptimizerClass(className: String): Optimizer = {
     ShimReflectionUtils.newInstanceOf[Optimizer](className)
-  }
-
-  def newParquetCachedBatchSerializer(): GpuCachedBatchSerializer = {
-    ShimReflectionUtils.newInstanceOf(
-      "com.nvidia.spark.rapids.parquet.ParquetCachedBatchSerializer")
   }
 
   def newExplainPlan(): ExplainPlanBase = {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/ParquetCachedBatchSerializer.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/parquet/ParquetCachedBatchSerializer.scala
@@ -31,7 +31,7 @@ import com.nvidia.spark.rapids.Arm.withResource
 import com.nvidia.spark.rapids.GpuColumnVector.GpuColumnarBatchBuilder
 import com.nvidia.spark.rapids.RapidsPluginImplicits._
 import com.nvidia.spark.rapids.ScalableTaskCompletion.onTaskCompletion
-import com.nvidia.spark.rapids.shims.{LegacyBehaviorPolicyShim, SparkShimImpl}
+import com.nvidia.spark.rapids.shims.{LegacyBehaviorPolicyShim, ParquetVariantShims, SparkShimImpl}
 import com.nvidia.spark.rapids.shims.parquet.{ParquetFieldIdShims, ParquetLegacyNanoAsLongShims, ParquetTimestampNTZShims}
 import org.apache.commons.io.output.ByteArrayOutputStream
 import org.apache.hadoop.conf.Configuration
@@ -1303,6 +1303,9 @@ class ParquetCachedBatchSerializer extends GpuCachedBatchSerializer {
 
     // From 3.3.2, Spark schema converter needs this conf
     ParquetLegacyNanoAsLongShims.setupLegacyParquetNanosAsLongForPCBS(hadoopConf)
+
+    // From 4.1.1, Spark will check this variant config
+    ParquetVariantShims.setupParquetVariantConfig(hadoopConf, sqlConf)
 
     hadoopConf
   }


### PR DESCRIPTION
- Modified the buildall script to ensure the MVN variable is correctly exported with options.
- Moved user-facing ParquetCachedBatchSerializer class to sql-plugin-api.
- Updated integration test requirements to include pytz.
- Updated Scala plugin version from 4.9.8 to 4.9.2 in both POM files for Scala 2.13.
- Modified the buildall script to ensure the MVN variable is correctly exported with options.

